### PR TITLE
Single experience

### DIFF
--- a/apollo/helpers.ts
+++ b/apollo/helpers.ts
@@ -11,6 +11,7 @@ import {
 } from '../lib/types';
 import { nanoid } from 'nanoid';
 import { filterById } from '../lib/utils/arrays';
+import { ApolloError } from '@apollo/client';
 
 const handleError = (e: Error): Error => {
   console.error(e); //eslint-disable-line no-console
@@ -45,7 +46,17 @@ export const getAllUserIds = (): string[] => {
 };
 
 export const getTalentById = async (id: string): Promise<Talent> => {
-  return await models.Talent.findOne({ id });
+  let talent: Talent | null = null;
+  try {
+    talent = await models.Talent.findOne({ id });
+  } catch (e) {
+    handleError(e);
+  }
+  if (!talent)
+    throw new ApolloError({
+      errorMessage: `404: No user with id ${id} found in db`,
+    });
+  return talent;
 };
 
 export const getOrganizationById = async (

--- a/components/experience-section/ExperienceEdit.tsx
+++ b/components/experience-section/ExperienceEdit.tsx
@@ -2,12 +2,13 @@ import { EditPopup } from '../edit-popup/EditPopup';
 import { TFunction } from 'next-i18next';
 import { Experience, Talent } from '../../lib/types';
 import { DialogProps, Box } from '@material-ui/core';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import InputField from '../input-field/InputField';
 import { ProfessionRadio } from '../profession-radio/ProfessionRadio';
 import CountrySelector from '../country-selector/CountrySelector';
 import { DatePicker } from '../date-picker/DatePicker';
 import { gql, MutationFunction, useMutation } from '@apollo/client';
+import { filterById } from '../../lib/utils/arrays';
 
 const DELETE_EXPERIENCE = gql`
   mutation Delete_Experience($input: DeleteExperience!) {
@@ -79,42 +80,47 @@ const ADD_EXPERIENCE = gql`
 interface ExperienceEditProps extends DialogProps {
   t: TFunction;
   id?: string;
-  experience?: Experience;
+  experiences: Experience[];
   talent: Talent;
   onClose: () => void;
 }
 
 export const ExperienceEdit = ({
   talent,
-  id,
-  experience = {
-    id: '',
-    talent,
-    lineOfWork: 'NURSE',
-    employer: {
-      id: '',
-      name: '',
-      address: {
-        city: '',
-        isoCode: '',
-      },
-    },
-    duration: {
-      from: {
-        timeStamp: Date.now().toString(),
-      },
-      to: {
-        timeStamp: '',
-      },
-    },
-    isComplete: false,
-  },
+  id = '',
+  experiences = [],
   t,
   ...props
 }: ExperienceEditProps): React.ReactElement => {
+  const newExperience: Experience = useMemo(
+    () => ({
+      id,
+      lineOfWork: 'NURSE',
+      talent,
+      isComplete: false,
+      duration: {
+        from: {
+          timeStamp: Date.now().toString(),
+        },
+        to: {
+          timeStamp: '',
+        },
+      },
+      description: '',
+      employer: {
+        id: '',
+        name: '',
+        address: {
+          city: '',
+          isoCode: '',
+        },
+      },
+    }),
+    [id, talent],
+  );
   const [updatedExperience, setUpdatedExperience] = useState<
     Partial<Experience>
-  >(experience);
+  >(newExperience);
 
   const [update] = useMutation(UPDATE_EXPERIENCE, {
     variables: {
@@ -177,16 +183,15 @@ export const ExperienceEdit = ({
   const [onDelete] = useMutation(DELETE_EXPERIENCE, {
     variables: {
       input: {
-        talent: experience.talent.id,
+        talent: updatedExperience.talent?.id,
         id,
       },
     },
   });
 
-  // TODO find better solution
   useEffect(() => {
-    setUpdatedExperience(() => experience);
-  }, [id]); //eslint-disable-line
+    setUpdatedExperience(filterById(experiences, id) || newExperience);
+  }, [id, experiences, newExperience]);
   return (
     <EditPopup
       t={t}
@@ -196,14 +201,16 @@ export const ExperienceEdit = ({
           : t('components.experienceEdit.title.new')
       }
       formId="experienceForm"
-      reset={() => setUpdatedExperience(experience)}
+      reset={() =>
+        setUpdatedExperience(filterById(experiences, id) || newExperience)
+      }
       mutate={(id ? update : add) as MutationFunction}
       onDelete={onDelete as MutationFunction}
       {...props}
     >
       <ProfessionRadio
         t={t}
-        input={experience?.lineOfWork}
+        input={updatedExperience?.lineOfWork}
         updateFunction={setUpdatedExperience}
         gender={talent.gender}
         isExtended={true}

--- a/pages/talents/[id]/profile.tsx
+++ b/pages/talents/[id]/profile.tsx
@@ -139,7 +139,11 @@ const ProfilePage = ({ t }: PageProps): React.ReactElement => {
     type: ModalType.NONE,
   });
   if (loading) return <h1>Loading</h1>;
-  if (error) return <h1>Error: {error.message}</h1>;
+  if (error) {
+    if (error.message.startsWith('404')) return <h1>insert 404 page here</h1>;
+    return <h1>Error: {error.message}</h1>;
+  }
+
   const basicInfo = data?.getTalentById.basicInfo;
   const experiences: Experience[] = data.getTalentById.experiences;
 

--- a/pages/talents/[id]/profile.tsx
+++ b/pages/talents/[id]/profile.tsx
@@ -10,7 +10,6 @@ import {
 } from '../../../components/experience-section';
 import { withTranslation } from '../../../i18n';
 import { useState } from 'react';
-import { filterById } from '../../../lib/utils/arrays';
 
 // export interface ProfilePageProps extends PageProps {
 //   id: string;
@@ -76,6 +75,7 @@ import { filterById } from '../../../lib/utils/arrays';
 //     }
 //   }
 // `;
+
 const GET_ALL_INFO = gql`
   query GetTalentById($id: String!) {
     getTalentById(id: $id) {
@@ -177,7 +177,7 @@ const ProfilePage = ({ t }: PageProps): React.ReactElement => {
         t={t}
         talent={basicInfo}
         id={modal.id}
-        experience={filterById(experiences, modal.id) as Experience}
+        experiences={experiences}
         onClose={handleModalClose}
         open={modal.type === ModalType.EXPERIENCE}
       />


### PR DESCRIPTION
quick refactor to avoid using useEffect in ExperienceEdit component.
PR also includes the previous pr for basic no-user-found handling for profile pages.