### PR TITLE
more error handling

### DIFF
--- a/components/error-handling/error-msg.tsx
+++ b/components/error-handling/error-msg.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Typography } from '@material-ui/core';
+
+type StandardErrorProps = {
+  errorMsg: string;
+};
+
+const ErrorMsg = ({ errorMsg }: StandardErrorProps): React.ReactElement => {
+  return <Typography>{errorMsg}</Typography>;
+};
+
+export default ErrorMsg;

--- a/components/error-handling/index.tsx
+++ b/components/error-handling/index.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { FirebaseError } from 'lib/types/auth';
+import { TFunction } from 'next-i18next';
+import ErrorMsg from './error-msg';
+import errorMap from 'lib/utils/error-maps';
+import { withTranslation } from 'i18n.config';
+
+type ErrorProps = {
+  t: TFunction;
+  error: FirebaseError;
+};
+
+const Error = ({ t, error }: ErrorProps): React.ReactElement => {
+  const { code, message } = error;
+
+  const specificErrorMsg = errorMap.get(code);
+
+  const errorMsg = specificErrorMsg ? t(specificErrorMsg) : message;
+
+  return <ErrorMsg errorMsg={errorMsg} />;
+};
+
+export default withTranslation('common')(Error);

--- a/hooks/useAuth.tsx
+++ b/hooks/useAuth.tsx
@@ -44,16 +44,19 @@ const useAuthProvider = (): UseAuthProviderReturnType => {
   }, []);
 
   const signup: Signup = (email, password) => {
-    return auth.createUserWithEmailAndPassword(email, password);
+    return auth
+      .createUserWithEmailAndPassword(email, password)
+      .catch((error) => error);
   };
 
   const signin: Signin = (email, password) => {
     return auth
       .signInWithEmailAndPassword(email, password)
-      .then((userCredential) => {
-        if (userCredential.user) setUser({ id: userCredential.user.uid });
-        return userCredential.user;
-      });
+      .then((response) => {
+        if (response.user) setUser({ id: response.user.uid });
+        return response.user;
+      })
+      .catch((error) => error);
   };
 
   const logout: Logout = () => {

--- a/lib/types/auth.ts
+++ b/lib/types/auth.ts
@@ -8,12 +8,12 @@ export type ContextUserType = {
 export type Signup = (
   email: string,
   password: string,
-) => Promise<firebase.auth.UserCredential>;
+) => Promise<firebase.auth.UserCredential | FirebaseError>;
 
 export type Signin = (
   email: string,
   password: string,
-) => Promise<firebase.User | void | null>;
+) => Promise<firebase.User | void | null | FirebaseError>;
 
 export type Logout = () => Promise<void>;
 
@@ -31,3 +31,11 @@ export type UseAuthProviderReturnType = {
 export type FirebaseUserCredential = firebase.auth.UserCredential;
 
 export type FirebaseUser = firebase.User;
+
+export type FirebaseError = firebase.auth.Error;
+
+export const isError = (
+  response: FirebaseUser | FirebaseUserCredential | FirebaseError | void | null,
+): response is FirebaseError => {
+  return (response as FirebaseError).code !== undefined;
+};

--- a/lib/utils/error-maps.ts
+++ b/lib/utils/error-maps.ts
@@ -1,0 +1,10 @@
+const errorMap = new Map();
+errorMap.set('auth/user-not-found', 'errors.auth.userNotFound');
+errorMap.set('auth/wrong-password', 'errors.auth.wrongPassword');
+errorMap.set('auth/too-many-requests', 'errors.auth.tooManyRequests');
+
+// SIGNUP ONLY
+errorMap.set('auth/weak-password', 'errors.auth.weakPassword');
+errorMap.set('auth/email-already-in-use', 'errors.auth.emailAlreadyInUse');
+
+export default errorMap;

--- a/pages/signin/index.tsx
+++ b/pages/signin/index.tsx
@@ -7,7 +7,8 @@ import { PageProps, UserInput } from '../../lib/types';
 import { withTranslation } from 'i18n.config';
 import styles from './Signin.module.css';
 import { useAuth } from '../../hooks/useAuth';
-import { FirebaseUser } from '../../lib/types/auth';
+import Error from 'components/error-handling';
+import { isError, FirebaseError } from 'lib/types/auth';
 
 const SignInPage = ({ t }: PageProps): React.ReactElement => {
   const [formValues, setFormValues] = useState<Partial<UserInput>>({
@@ -19,6 +20,7 @@ const SignInPage = ({ t }: PageProps): React.ReactElement => {
     password: '',
     type: 'TALENT',
   });
+  const [error, setError] = useState<FirebaseError | null>(null);
   const auth = useAuth();
 
   const handleLogout = (e: React.MouseEvent<HTMLButtonElement>): void => {
@@ -29,16 +31,11 @@ const SignInPage = ({ t }: PageProps): React.ReactElement => {
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>): void => {
     e.preventDefault();
     if (formValues.email && formValues.password) {
+      setError(null);
       auth
         .signin(formValues.email, formValues.password)
-        .then((user: FirebaseUser | void | null) => {
-          if (typeof user === null) {
-            //eslint-disable-next-line no-console
-            console.error(
-              'wrong email or password, current user still is: ',
-              auth.user,
-            );
-          }
+        .then((response) => {
+          if (isError(response)) setError(response);
         })
         .catch((error: Error) => console.error(error)); //eslint-disable-line no-console
     }
@@ -46,6 +43,7 @@ const SignInPage = ({ t }: PageProps): React.ReactElement => {
 
   return (
     <Layout title="sign in" t={t}>
+      {error && <Error error={error} />}
       <Card>
         <CardContent>
           <Container>

--- a/public/static/locales/de/common.json
+++ b/public/static/locales/de/common.json
@@ -200,5 +200,14 @@
   "type": {
     "employer": "Arbeitgeber",
     "talent": "Talent"
+  },
+  "errors": {
+    "auth": {
+      "userNotFound": "Es konnte kein Benutzer mit dieser E-Mail-Adresse gefunden werden. Bitte versuchen Sie es erneut oder registrieren Sie sich.",
+      "wrongPassword": "Inkorrektes Passwort. Bitte versuchen Sie es erneut. Falls Sie Ihr Passwort vergessen haben, klicken Sie auf \"Passwort zurücksetzen\".",
+      "tooManyRequests": "Zu viele Anmeldeversuche. Aus Sicherheitsgründen wurde Ihr Account vorrübergehen blockiert. Setzen Sie Ihr Passwort zurück oder versuchen Sie es später erneut.",
+      "weakPassword": "Das Passwort muss mindestens sechs Zeichen lang sein.",
+      "emailAlreadyInUse": "Diese E-Mail-Adresse wird bereits für einen Account benutzt. Bitte melden Sie sich an oder verwenden eine andere E-Mail-Adresse."
+    }
   }
 }

--- a/public/static/locales/en/common.json
+++ b/public/static/locales/en/common.json
@@ -206,5 +206,14 @@
   "type": {
     "employer": "Employer",
     "talent": "Talent"
+  },
+  "errors": {
+    "auth": {
+      "userNotFound": "No User found for this email address. Please try again or register.",
+      "wrongPassword": "Wrong password. Please try again. If you forgot your password, please click on \"reset password\".",
+      "tooManyRequests": "Too many login attempts. Please reset your password or try again later.",
+      "weakPassword": "The password needs to be at least 6 characters long",
+      "emailAlreadyInUse": "This email is already in use for another account. Please log in with this email or register with a different email"
+    }
   }
 }


### PR DESCRIPTION
https://kara-jobs.atlassian.net/browse/KM-44

- show a translated error message to the user
- customised message is shown for most common errors, including the errors mentioned here: https://kara-jobs.atlassian.net/browse/KM-48 and here: https://kara-jobs.atlassian.net/browse/KM-49

Next Steps:
- Basic styling of error msg: https://kara-jobs.atlassian.net/browse/KM-86
- Redirect logic: E.g. if user is already logged in and clicks on signin, then redirect to profile page. Similar with signup. Not sure if we want to tackle this separately for signin / signup (e.g. write a hook only for this purpose) or whether we want to include this in the authorisation ticket (here we will need a hook anyways that does some redirect logic).
