### PR TITLE
add authStateChangeFinished flag

### DIFF
--- a/hocs/withAuthorization.tsx
+++ b/hocs/withAuthorization.tsx
@@ -3,6 +3,7 @@ import { useAuth } from 'hooks/useAuth';
 import { UserGroup } from 'lib/types';
 import { ContextUserType } from 'lib/types/auth';
 import { useRouter } from 'next/router';
+import { Loader } from 'components';
 
 const editorIds = ['Kx00tfTGy6ei8olseVTJc988f992'];
 
@@ -31,7 +32,7 @@ const withAuthorization = <Props extends object>( //eslint-disable-line
     const { user, authStateChangeFinished } = useAuth();
     const id = useRouter().query.id as string;
 
-    if (!authStateChangeFinished) return null;
+    if (!authStateChangeFinished) return <Loader />;
 
     if (!user || !user.id) {
       return <Unauthorized />;

--- a/hocs/withAuthorization.tsx
+++ b/hocs/withAuthorization.tsx
@@ -31,7 +31,7 @@ const withAuthorization = <Props extends object>( //eslint-disable-line
     const { user, authStateChangeFinished } = useAuth();
     const id = useRouter().query.id as string;
 
-    if (!authStateChangeFinished) return <></>;
+    if (!authStateChangeFinished) return null;
 
     if (!user || !user.id) {
       return <Unauthorized />;

--- a/hocs/withAuthorization.tsx
+++ b/hocs/withAuthorization.tsx
@@ -28,8 +28,10 @@ const withAuthorization = <Props extends object>( //eslint-disable-line
   Page: React.ComponentType<Props & { editable: boolean }>,
 ): React.ComponentType<Props> =>
   function PageWithAuthorization(props) {
-    const { user } = useAuth();
+    const { user, authStateChangeFinished } = useAuth();
     const id = useRouter().query.id as string;
+
+    if (!authStateChangeFinished) return <></>;
 
     if (!user || !user.id) {
       return <Unauthorized />;

--- a/hooks/useAuth.tsx
+++ b/hooks/useAuth.tsx
@@ -32,10 +32,14 @@ export const useAuth: () => UseAuthProviderReturnType = () => {
 
 const useAuthProvider = (): UseAuthProviderReturnType => {
   const [user, setUser] = useState<ContextUserType>({ id: '' });
+  const [authStateChangeFinished, setAuthStateChangeFinished] = useState(false);
 
   const handleAuthStateChanged = (user: firebase.User | null): void => {
     //can save additional data here, e.g. type
-    if (user) setUser({ id: user.uid });
+    if (user) {
+      setUser({ id: user.uid });
+      setAuthStateChangeFinished(true);
+    }
   };
 
   useEffect(() => {
@@ -86,5 +90,6 @@ const useAuthProvider = (): UseAuthProviderReturnType => {
     logout,
     sendPasswordResetEmail,
     setContextUser,
+    authStateChangeFinished,
   };
 };

--- a/lib/types/auth.ts
+++ b/lib/types/auth.ts
@@ -28,6 +28,7 @@ export type UseAuthProviderReturnType = {
   logout: Logout;
   sendPasswordResetEmail: sendPasswordResetEmail;
   setContextUser: (user: ContextUserType) => void;
+  authStateChangeFinished: boolean;
 };
 
 export type FirebaseUserCredential = firebase.auth.UserCredential;


### PR DESCRIPTION
The `useAuth` hook now returns a flag that shows if the auth state change has finished or not.

This flag will always be `true` after the authentication state aka the user in the context has been changed once. Consumers can check this flag to tackle the problem mentioned in this PR: https://github.com/fullstacksmart/next-kara/pull/50. 