### PR TITLE
[KM-99] UseTranslation hook

### DIFF
--- a/components/error/index.tsx
+++ b/components/error/index.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import { FirebaseError } from 'lib/types/auth';
-import { TFunction } from 'next-i18next';
 import ErrorMsg from './error-msg';
 import errorMap from 'lib/utils/error-maps';
-import { withTranslation } from 'i18n.config';
+import { useTranslation } from 'react-i18next';
 
 type ErrorProps = {
-  t: TFunction;
   error: FirebaseError;
 };
 
-const Error = ({ t, error }: ErrorProps): React.ReactElement => {
+const Error = ({ error }: ErrorProps): React.ReactElement => {
+  const { t } = useTranslation('common');
+
   const { code, message } = error;
 
   const specificErrorMsg = errorMap.get(code);
@@ -20,4 +20,4 @@ const Error = ({ t, error }: ErrorProps): React.ReactElement => {
   return <ErrorMsg errorMsg={errorMsg} />;
 };
 
-export default withTranslation('common')(Error);
+export default Error;

--- a/containers/layout/Layout.tsx
+++ b/containers/layout/Layout.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Container from '@material-ui/core/Container';
-import { I18n, TFunction } from 'next-i18next';
 import Head from 'next/head';
 import Footer from 'components/footer/Footer';
 import useStyles from './LayoutStyles';
@@ -10,19 +9,17 @@ import { Button } from 'components';
 import { useAuth } from 'hooks/useAuth';
 import { useRouter } from 'next/router';
 import Error from 'components/error';
-import { withTranslation } from 'i18n.config';
 import { layoutTitleVar, layoutHeadingVar, layoutErrorVar } from 'apollo/cache';
 import { useReactiveVar } from '@apollo/client';
 import { getTitleStringFromPathname } from 'lib/utils/strings';
-
+import { useTranslation } from 'react-i18next';
 export interface LayoutProps {
   children?: React.ReactNode;
-  i18n?: I18n;
-  t: TFunction;
 }
 
-const Layout = ({ children, t, i18n }: LayoutProps): React.ReactElement => {
+const Layout = ({ children }: LayoutProps): React.ReactElement => {
   const classes = useStyles();
+  const { t, i18n } = useTranslation('common');
   const auth = useAuth();
   const router = useRouter();
   const { pathname } = router;
@@ -92,4 +89,4 @@ const Layout = ({ children, t, i18n }: LayoutProps): React.ReactElement => {
   );
 };
 
-export default withTranslation('common')(Layout);
+export default Layout;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4833,12 +4833,12 @@
         "react-is": "^16.7.0"
       }
     },
-    "html-parse-stringify2": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/html-parse-stringify2/-/html-parse-stringify2-2.0.1.tgz",
-      "integrity": "sha1-3FZwtyksoVi3vJFsmmc1rIhyg0o=",
+    "html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
       "requires": {
-        "void-elements": "^2.0.1"
+        "void-elements": "3.1.0"
       }
     },
     "htmlparser2": {
@@ -7143,12 +7143,22 @@
       }
     },
     "react-i18next": {
-      "version": "11.8.5",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.8.5.tgz",
-      "integrity": "sha512-2jY/8NkhNv2KWBnZuhHxTn13aMxAbvhiDUNskm+1xVVnrPId78l8fA7fCyVeO3XU1kptM0t4MtvxV1Nu08cjLw==",
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.11.0.tgz",
+      "integrity": "sha512-p1jHmoyJgDFQmyubUEjrx6kCsr1izW/C8i9pOiJy+9lJqLYwNA8sElVplm0VAnop3kH68edT0/g3wB3UvAcRCQ==",
       "requires": {
-        "@babel/runtime": "^7.3.1",
-        "html-parse-stringify2": "2.0.1"
+        "@babel/runtime": "^7.14.5",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.14.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+          "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
       }
     },
     "react-is": {
@@ -8785,9 +8795,9 @@
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
     },
     "void-elements": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
-      "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha1-YU9/v42AHwu18GYfWy9XhXUOTwk="
     },
     "watchpack": {
       "version": "2.0.0-beta.13",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "prisma": "^2.20.1",
     "react": "17.0.1",
     "react-dom": "17.0.1",
+    "react-i18next": "^11.11.0",
     "react-material-ui-carousel": "^2.1.1"
   },
   "devDependencies": {

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -1,20 +1,21 @@
-import { withTranslation } from '../i18n.config';
 import type { NextPageContext } from 'next';
-import { TFunction } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 const Error = ({
   statusCode,
-  t,
 }: {
   statusCode: number | null;
-  t: TFunction;
-}): React.ReactElement => (
-  <p>
-    {statusCode
-      ? t('error-with-status', { statusCode })
-      : t('error-without-status')}
-  </p>
-);
+}): React.ReactElement => {
+  const { t } = useTranslation('common');
+
+  return (
+    <p>
+      {statusCode
+        ? t('error-with-status', { statusCode })
+        : t('error-without-status')}
+    </p>
+  );
+};
 
 Error.getInitialProps = async ({ res, err }: NextPageContext) => {
   let statusCode = null;
@@ -33,4 +34,4 @@ Error.defaultProps = {
   statusCode: null,
 };
 
-export default withTranslation('common')(Error);
+export default Error;

--- a/pages/employers/[id]/profile.tsx
+++ b/pages/employers/[id]/profile.tsx
@@ -1,12 +1,11 @@
 // import { GetStaticPaths, GetStaticProps } from 'next';
 import { Button } from '../../../components/buttons';
 import { PageProps } from '../../../lib/types';
-
 export interface ProfilePageProps extends PageProps {
   id: string;
 }
 
-const ProfilePage = ({ id, t }: ProfilePageProps): React.ReactElement => {
+const ProfilePage = ({ id }: ProfilePageProps): React.ReactElement => {
   return (
     <>
       <h1>Profile Page for Employer {id}</h1>
@@ -35,5 +34,9 @@ const ProfilePage = ({ id, t }: ProfilePageProps): React.ReactElement => {
 //     },
 //   };
 // };
+
+ProfilePage.getInitialProps = async () => ({
+  namespacesRequired: ['common'],
+});
 
 export default ProfilePage;

--- a/pages/employers/[id]/settings.tsx
+++ b/pages/employers/[id]/settings.tsx
@@ -17,4 +17,8 @@ const SettingsPage = ({ id, t }: SettingsPageProps): React.ReactElement => {
 
 // export { getStaticPaths, getStaticProps };
 
+SettingsPage.getInitialProps = async () => ({
+  namespacesRequired: ['common'],
+});
+
 export default SettingsPage;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,17 +1,6 @@
-// import PropTypes from 'prop-types'
-// import { withTranslation } from '../i18n';
-// import TranslateIcon from "@material-ui/icons/Translate";
-// import { Button } from '../components/buttons';
-import HomePage from '../containers/Home/HomePage';
-import { PageProps } from '../lib/types';
-import { withTranslation } from '../i18n.config';
+import HomePage from 'containers/Home/HomePage';
 
-const Home = ({ t }: PageProps): React.ReactElement => {
-  // const handleClick = (): void => {
-  //   const newLang = i18n.language === 'en' ? 'de' : 'en'
-  //   i18n.changeLanguage(newLang)
-  // }
-
+const Home = (): React.ReactElement => {
   return <HomePage />;
 };
 
@@ -19,4 +8,4 @@ Home.getInitialProps = async () => ({
   namespacesRequired: ['common'],
 });
 
-export default withTranslation('common')(Home);
+export default Home;

--- a/pages/reset-password/index.tsx
+++ b/pages/reset-password/index.tsx
@@ -2,17 +2,18 @@ import { Button } from '../../components/buttons';
 import { Card, CardContent, Typography, Container } from '@material-ui/core';
 import InputField from '../../components/input-field/InputField';
 import { useState } from 'react';
-import { PageProps, UserInput } from '../../lib/types';
-import { withTranslation } from '../../i18n.config';
+import { UserInput } from '../../lib/types';
 import styles from './ResetPassword.module.css';
 import { useAuth } from '../../hooks/useAuth';
+import { useTranslation } from 'react-i18next';
 
-const PasswordResetPage = ({ t }: PageProps): React.ReactElement => {
+const PasswordResetPage = (): React.ReactElement => {
   const [formValues, setFormValues] = useState<Partial<UserInput>>({
     email: '',
   });
 
   const auth = useAuth();
+  const { t } = useTranslation('common');
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>): void => {
     e.preventDefault();
@@ -43,4 +44,8 @@ const PasswordResetPage = ({ t }: PageProps): React.ReactElement => {
   );
 };
 
-export default withTranslation('common')(PasswordResetPage);
+PasswordResetPage.getInitialProps = async () => ({
+  namespacesRequired: ['common'],
+});
+
+export default PasswordResetPage;

--- a/pages/signin/index.tsx
+++ b/pages/signin/index.tsx
@@ -2,26 +2,26 @@ import { Button } from 'components/buttons';
 import { Card, CardContent, Typography, Container } from '@material-ui/core';
 import InputField from 'components/input-field/InputField';
 import { Dispatch, SetStateAction, useState, useEffect } from 'react';
-import { PageProps } from '../../lib/types';
-import { withTranslation } from 'i18n.config';
 import styles from './Signin.module.css';
 import { useAuth } from '../../hooks/useAuth';
 import { isError } from 'lib/types/auth';
 import { useRouter } from 'next/router';
 import { layoutErrorVar } from 'apollo/cache';
+import { useTranslation } from 'react-i18next';
 
 interface FormValues {
   email: string;
   password: string;
 }
 
-const SignInPage = ({ t }: PageProps): React.ReactElement => {
+const SignInPage = (): React.ReactElement => {
   const router = useRouter();
   const [formValues, setFormValues] = useState<FormValues>({
     email: '',
     password: '',
   });
   const auth = useAuth();
+  const { t } = useTranslation('common');
 
   useEffect(
     () => () => {
@@ -86,4 +86,8 @@ const SignInPage = ({ t }: PageProps): React.ReactElement => {
   );
 };
 
-export default withTranslation('common')(SignInPage);
+SignInPage.getInitialProps = async () => ({
+  namespacesRequired: ['common'],
+});
+
+export default SignInPage;

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -10,7 +10,6 @@ import { Button } from 'components/buttons';
 import InputField from 'components/input-field/InputField';
 import { Dispatch, SetStateAction, useState, useEffect } from 'react';
 import { SignupFormValues } from 'lib/types';
-import { withTranslation } from 'i18n.config';
 import { useMutation, gql } from '@apollo/client';
 import styles from './Signup.module.css';
 import { GenderSelector } from 'components/gender-selector/GenderSelector';
@@ -258,4 +257,4 @@ SignUpPage.getInitialProps = async () => ({
   namespacesRequired: ['common'],
 });
 
-export default withTranslation('common')(SignUpPage);
+export default SignUpPage;

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -9,7 +9,7 @@ import OptionsToggler from 'components/option-toggler/OptionToggler';
 import { Button } from 'components/buttons';
 import InputField from 'components/input-field/InputField';
 import { Dispatch, SetStateAction, useState, useEffect } from 'react';
-import { PageProps, SignupFormValues } from 'lib/types';
+import { SignupFormValues } from 'lib/types';
 import { withTranslation } from 'i18n.config';
 import { useMutation, gql } from '@apollo/client';
 import styles from './Signup.module.css';
@@ -22,6 +22,7 @@ import { isError } from 'lib/types/auth';
 import { useRouter } from 'next/router';
 import { computeNestedValue, getPropArray } from 'lib/utils/arrays';
 import { layoutErrorVar } from 'apollo/cache';
+import { useTranslation } from 'react-i18next';
 
 const ADD_EMPLOYER = gql`
   mutation AddEmployer($input: UserInput!) {
@@ -42,7 +43,7 @@ const ADD_TALENT = gql`
 // Min 8 characters. At least 1 capital, 1 number
 const strongCombination = new RegExp(/^(?=.*?[0-9])(?=.*?[A-Z]).{8,}$/);
 
-const SignUpPage = ({ t }: PageProps): React.ReactElement => {
+const SignUpPage = (): React.ReactElement => {
   const [formValues, setFormValues] = useState<SignupFormValues>(
     defaultSignupFormValues,
   );
@@ -53,6 +54,7 @@ const SignUpPage = ({ t }: PageProps): React.ReactElement => {
   const [passwordRepeat, setPasswordRepeat] = useState<Record<string, unknown>>(
     { passwordConfirm: '' },
   );
+  const { t } = useTranslation('common');
 
   useEffect(
     () => () => {
@@ -251,5 +253,9 @@ const SignUpPage = ({ t }: PageProps): React.ReactElement => {
     </Card>
   );
 };
+
+SignUpPage.getInitialProps = async () => ({
+  namespacesRequired: ['common'],
+});
 
 export default withTranslation('common')(SignUpPage);

--- a/pages/talents/[id]/ProfilePage.tsx
+++ b/pages/talents/[id]/ProfilePage.tsx
@@ -17,7 +17,6 @@ import {
   Skill,
   SkillLevel,
 } from 'lib/types';
-import { withTranslation } from 'i18n.config';
 import { useState, useEffect } from 'react';
 import {
   BasicInfo,
@@ -38,6 +37,7 @@ import {
 import useStyles from './ProfilePage.styles';
 import { getTitleString } from 'lib/utils/strings';
 import { layoutTitleVar, layoutHeadingVar } from 'apollo/cache';
+import { useTranslation } from 'react-i18next';
 
 const GET_ALL_TALENTS = gql`
   query getAllTalentIds {
@@ -139,7 +139,7 @@ const GET_ALL_INFO = gql`
   }
 `;
 
-const ProfilePage = ({ t }: PageProps): React.ReactElement => {
+const ProfilePage = (): React.ReactElement => {
   const { data: talentIds, loading: idLoading } = useQuery(GET_ALL_TALENTS);
   const classes = useStyles();
   const id = useRouter().query.id;
@@ -151,6 +151,7 @@ const ProfilePage = ({ t }: PageProps): React.ReactElement => {
   const [modal, setModal] = useState<{ type: ModalType; id?: string }>({
     type: ModalType.NONE,
   });
+  const { t } = useTranslation('common');
 
   useEffect(() => {
     if (data) {
@@ -310,4 +311,8 @@ const ProfilePage = ({ t }: PageProps): React.ReactElement => {
   );
 };
 
-export default withTranslation('common')(ProfilePage);
+ProfilePage.getInitialProps = async () => ({
+  namespacesRequired: ['common'],
+});
+
+export default ProfilePage;

--- a/pages/talents/[id]/ProfilePage.tsx
+++ b/pages/talents/[id]/ProfilePage.tsx
@@ -11,7 +11,6 @@ import {
   FederalState,
   Gender,
   ModalType,
-  PageProps,
   Profession,
   Qualification,
   Skill,

--- a/pages/talents/[id]/settings.tsx
+++ b/pages/talents/[id]/settings.tsx
@@ -1,12 +1,13 @@
 import { Button } from '../../../components/buttons';
-import { withTranslation } from '../../../i18n.config';
 import { PageProps } from '../../../lib/types';
-
+import { useTranslation } from 'react-i18next';
 export interface SettingsPageProps extends PageProps {
   id: string;
 }
 
-const SettingsPage = ({ id, t }: SettingsPageProps): React.ReactElement => {
+const SettingsPage = ({ id }: SettingsPageProps): React.ReactElement => {
+  const { t } = useTranslation('common');
+
   return (
     <>
       <h1>Settings Page for Talent {id}</h1>
@@ -19,4 +20,4 @@ SettingsPage.getInitialProps = async () => ({
   namespacesRequired: ['common'],
 });
 
-export default withTranslation('common')(SettingsPage);
+export default SettingsPage;


### PR DESCRIPTION
https://kara-jobs.atlassian.net/browse/KM-99

ChangeLog:
- install `react-i18next` and use the `useTranslation` hook from there. The hook can be used together with our package (`next-i18next`)
- fix the warning "no namespace provided...." by adding e.g. ```ProfilePage.getInitialProps = async () => ({
  namespacesRequired: ['common'],
});``` to all pages

--> The result of this PR is that we 
- don't need to get `t` from the `PageProps` anymore
- don't need to export our pages and components with `withTranslation` anymore
- need to import `useTranslation` hook wherever we need the `t` or `i18n`
- need to add the namespace to all our pages (not components) with `getInitialProps`
- only pass the namespace to a page that is necessary for a page (if we wanted to add more namespaces in the future, this would increase performance)
